### PR TITLE
Adds test with grpcurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ curl http://localhost:8080/file/9c73cde3-d8f9-4048-bfd9-00e0484fdb89 -H 'Origin:
 curl -X POST http://localhost:8080/move -H 'Origin: http://localhost:3000' -d '{"sourceID": "7a1ced19-5396-4c44-bc30-4953d59453d5", "destinationID": "0871b5af-4954-4d21-9e1f-3781e269374a", "newName": "cloud-auth-moved"}'
 ```
 
+## Testing gRPC endpoints with grpcurl
+```
+go get github.com/fullstorydev/grpcurl
+go install github.com/fullstorydev/grpcurl/cmd/grpcurl
+grpcurl -v -plaintext localhost:50051 list pb.FileService
+grpcurl -v -plaintext -d '{"userID": "4", "fileID": "7a1ced19-5396-4c44-bc30-4953d59453d5"}' localhost:50051 pb.FileService/GetFile
+```
+
 ## Reading
 - [Docker Compose reference](https://docs.docker.com/compose/compose-file/)
 - [Background on Seabolt driver](https://medium.com/neo4j/neo4j-go-driver-is-out-fbb4ba5b3a30)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,11 @@ services:
       - NEO_HOSTNAME=neo4j
       - NEO_USERNAME=neo4j
       - NEO_PASSWORD=${NEO_PASSWORD}
+      - APP_PORT=8080
+      - GRPC_PORT=50051
     ports:
       - "8080:8080"
+      - "50051:50051"
 
   neo4j:
     image: neo4j:latest

--- a/src/app.go
+++ b/src/app.go
@@ -34,7 +34,7 @@ type App struct {
 	FolderController       folder.Controller
 }
 
-func NewApp(driverInfo neo.DriverInfo) *App {
+func NewApp(driverInfo neo.DriverInfo, grpcPort int) *App {
 	userService := userNeo.NewService(driverInfo)
 	organizationService := orgNeo.NewService(driverInfo)
 	moveService := moveNeo.NewService(driverInfo)
@@ -43,7 +43,7 @@ func NewApp(driverInfo neo.DriverInfo) *App {
 
 	a := &App{
 		GrpcServer: grpc.Server{
-			Port:                50051,
+			Port:                grpcPort,
 			UserService:         userService,
 			OrganizationService: organizationService,
 			MoveService:         moveService,

--- a/src/grpc/server.go
+++ b/src/grpc/server.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net"
 
+	"github.com/google/uuid"
+
 	"github.com/kevinmichaelchen/neo4j-go-file-system/file"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/folder"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/move"
@@ -53,18 +55,48 @@ func (s *Server) DeleteUser(ctx context.Context, in *pb.DeleteUserRequest) (*pb.
 	return nil, nil
 }
 
+func (s *Server) CreateFile(ctx context.Context, in *pb.CreateFileRequest) (*pb.CreateFileResponse, error) {
+	return nil, nil
+}
+
+func (s *Server) GetFile(ctx context.Context, in *pb.GetFileRequest) (*pb.GetFileResponse, error) {
+	fileID, err := uuid.Parse(in.FileID)
+	if err != nil {
+		return nil, err
+	}
+	// TODO pass in in.UserID and perform security/authorization
+	f, svcErr := s.FileService.GetFile(fileID)
+	if svcErr != nil {
+		return nil, svcErr.Error
+	}
+	return &pb.GetFileResponse{File: &pb.File{
+		FileID:   f.ResourceID.String(),
+		ParentID: f.ParentID.String(),
+		Name:     f.Name,
+		// TODO revisionID
+	}}, nil
+}
+
+func (s *Server) UpdateFile(ctx context.Context, in *pb.UpdateFileRequest) (*pb.UpdateFileResponse, error) {
+	return nil, nil
+}
+
+func (s *Server) DeleteFile(ctx context.Context, in *pb.DeleteFileRequest) (*pb.DeleteFileResponse, error) {
+	return nil, nil
+}
+
 func (s *Server) Run() {
 	address := fmt.Sprintf(":%d", s.Port)
-	log.Printf("Serving gRPC on %s\n", address)
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Fatalf("Failed to listen: %v", err)
 	}
-	log.Println("Starting gRPC server...")
+	log.Printf("Starting gRPC server on %s...\n", address)
 	server := grpc.NewServer()
 
 	// Register our services
 	pb.RegisterUserServiceServer(server, s)
+	pb.RegisterFileServiceServer(server, s)
 
 	// Register reflection service on gRPC server.
 	reflection.Register(server)

--- a/src/main.go
+++ b/src/main.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/kevinmichaelchen/neo4j-go-file-system/neo"
 )
 
 func main() {
-	var hostname, user, pass string
+	var hostname, user, pass, appPortString, grpcPortString string
 	var ok bool
 	if hostname, ok = os.LookupEnv("NEO_HOSTNAME"); !ok {
 		log.Fatal("Failed to specify hostname")
@@ -20,13 +21,29 @@ func main() {
 	if pass, ok = os.LookupEnv("NEO_PASSWORD"); !ok {
 		log.Fatal("Failed to specify password")
 	}
+	if appPortString, ok = os.LookupEnv("APP_PORT"); !ok {
+		log.Fatal("Failed to specify app port")
+	}
+	if grpcPortString, ok = os.LookupEnv("GRPC_PORT"); !ok {
+		log.Fatal("Failed to specify gRPC port")
+	}
+
+	appPort, err := strconv.Atoi(appPortString)
+	if err != nil {
+		log.Fatalf("Failed to specify valid app port: %s", appPortString)
+	}
+
+	grpcPort, err := strconv.Atoi(grpcPortString)
+	if err != nil {
+		log.Fatalf("Failed to specify valid gRPC port: %s", grpcPortString)
+	}
+
 	connectionString := fmt.Sprintf("bolt://%s:7687", hostname)
 	log.Printf("Connecting to: %s", connectionString)
 
 	driverInfo := neo.DriverInfo{ConnectionUri: connectionString, Username: user, Password: pass}
 	neo.InitializeObjects(driverInfo)
 
-	a := NewApp(driverInfo)
-	port := 8080
-	a.ServeRest(fmt.Sprintf(":%d", port), "http://localhost:3000")
+	a := NewApp(driverInfo, grpcPort)
+	a.ServeRest(fmt.Sprintf(":%d", appPort), "http://localhost:3000")
 }


### PR DESCRIPTION
Confirmed that our gRPC is behaving normally with [grpcurl](https://github.com/fullstorydev/grpcurl).

It's basically like `curl` but for gRPC.

You can do stuff like

```
grpcurl -v -plaintext -d '{"userID": "4", "fileID": "7a1ced19-5396-4c44-bc30-4953d59453d5"}' localhost:50051 pb.FileService/GetFile
```

and get back an actual non-binary JSON response
```son
{
  "file": {
    "fileID": "7a1ced19-5396-4c44-bc30-4953d59453d5",
    "name": "cloud-auth.md",
    "parentID": "be94511e-c8b1-4e62-b37d-2e35704ea6c2"
  }
}
```