### PR TITLE
Debugging "nil pointer dereference" bug in "create org" gRPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,30 @@ curl http://localhost:8080/file/9c73cde3-d8f9-4048-bfd9-00e0484fdb89 -H 'Origin:
 curl -X POST http://localhost:8080/move -H 'Origin: http://localhost:3000' -d '{"sourceID": "7a1ced19-5396-4c44-bc30-4953d59453d5", "destinationID": "0871b5af-4954-4d21-9e1f-3781e269374a", "newName": "cloud-auth-moved"}'
 ```
 
-## Testing gRPC endpoints with grpcurl
-[grpcurl](https://github.com/fullstorydev/grpcurl) lets us interact with a gRPC server as easily as we use REST APIs and `curl`.
-Without it, we'd have a difficult time inspecting binary payloads on the command line.
-```
+## gRPC API
+We can test out our gRPC API on the command line with [grpcurl](https://github.com/fullstorydev/grpcurl).
+It behaves like `curl`, but it can process binary payloads.
+
+To install it, run
+```bash
 go get github.com/fullstorydev/grpcurl
 go install github.com/fullstorydev/grpcurl/cmd/grpcurl
+```
+
+There are some calls you can make to see what kinds of methods your API supports:
+```bash
 grpcurl -import-path ./src/pb -proto file.proto list
 grpcurl -v -plaintext localhost:50051 list pb.FileService
+```
+
+### Files
+```bash
 grpcurl -v -plaintext -d '{"userID": "4", "fileID": "7a1ced19-5396-4c44-bc30-4953d59453d5"}' localhost:50051 pb.FileService/GetFile
+```
+
+### Organizations
+```bash
+grpcurl -v -plaintext -d '{"organization": {"organizationID": 2, "name": "My Custom Org"}}' localhost:50051 pb.OrganizationService/CreateOrganization
 ```
 
 ## Reading

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ grpcurl -v -plaintext -d '{"userID": "4", "fileID": "7a1ced19-5396-4c44-bc30-495
 
 ### Organizations
 ```bash
-grpcurl -v -plaintext -d '{"organization": {"organizationID": 2, "name": "My Custom Org"}}' localhost:50051 pb.OrganizationService/CreateOrganization
+grpcurl -v -plaintext -d '{"organization": {"id": 2, "name": "My Custom Org"}}' localhost:50051 pb.OrganizationService/CreateOrganization
 ```
 
 ## Reading

--- a/src/file/neo/neo.go
+++ b/src/file/neo/neo.go
@@ -3,14 +3,12 @@ package neo
 import (
 	"context"
 	"fmt"
-	"log"
-	"net/http"
-
 	"github.com/google/uuid"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/file"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/neo"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/service"
 	"github.com/neo4j/neo4j-go-driver/neo4j"
+	"log"
 )
 
 type Service struct {
@@ -46,7 +44,7 @@ func (s *Service) GetFile(context context.Context, in file.File) (*file.File, *s
 	}
 
 	if resource == nil {
-		return nil, service.NewError(http.StatusNotFound, fmt.Sprintf("No file found for ID: %s", in.ResourceID.String()), nil)
+		return nil, service.NotFound(fmt.Sprintf("No file found for ID: %s", in.ResourceID.String()))
 	}
 
 	// TODO verify user can read file

--- a/src/file/neo/neo.go
+++ b/src/file/neo/neo.go
@@ -3,12 +3,13 @@ package neo
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/google/uuid"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/file"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/neo"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/service"
 	"github.com/neo4j/neo4j-go-driver/neo4j"
-	"log"
 )
 
 type Service struct {

--- a/src/grpc/organization.go
+++ b/src/grpc/organization.go
@@ -6,12 +6,15 @@ import (
 	"golang.org/x/net/context"
 )
 
-func CreateOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
-	u, svcError := organizationService.CreateOrganization(toOrganization(in.Organization))
+func CreateOrganization(organizationService organization.Service, ctx context.Context, in *pb.CreateOrgRequest) (*pb.CreateOrgResponse, error) {
+	o, svcError := organizationService.CreateOrganization(toOrganization(in.Organization))
 	if svcError.Error != nil {
 		return nil, svcError.Error
 	}
-	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	// TODO this line is bombing w/ invalid memory address or nil pointer dereference
+	return &pb.CreateOrgResponse{Organization: &pb.Organization{
+		Id: o.ResourceID,
+		Name: o.Name}}, nil
 }
 
 func GetOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
@@ -50,16 +53,16 @@ func RemoveUserFromOrganization(organizationService organization.Service, ctx co
 	return nil, nil
 }
 
-func toOrganization(u *pb.Organization) organization.Organization {
+func toOrganization(in *pb.Organization) organization.Organization {
 	return organization.Organization{
-		ResourceID: u.Id,
-		Name:       u.Name,
+		ResourceID: in.Id,
+		Name:       in.Name,
 	}
 }
 
-func toGrpcOrganization(u *organization.Organization) *pb.Organization {
+func toGrpcOrganization(in *organization.Organization) *pb.Organization {
 	return &pb.Organization{
-		Id:   u.ResourceID,
-		Name: u.Name,
+		Id:   in.ResourceID,
+		Name: in.Name,
 	}
 }

--- a/src/grpc/organization.go
+++ b/src/grpc/organization.go
@@ -4,45 +4,45 @@ import (
 	"github.com/kevinmichaelchen/neo4j-go-file-system/organization"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/pb"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/status"
 )
 
-func CreateOrganization(organizationService organization.Service, ctx context.Context, in *pb.CreateOrgRequest) (*pb.CreateOrgResponse, error) {
-	o, svcError := organizationService.CreateOrganization(toOrganization(in.Organization))
-	if svcError.Error != nil {
-		return nil, svcError.Error
+func CreateOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
+	o, svcErr := organizationService.CreateOrganization(toOrganization(in.Organization))
+
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
-	// TODO this line is bombing w/ invalid memory address or nil pointer dereference
-	return &pb.CreateOrgResponse{Organization: &pb.Organization{
-		Id: o.ResourceID,
-		Name: o.Name}}, nil
+
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(o)}, nil
 }
 
 func GetOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
-	u, svcError := organizationService.GetOrganization(organization.Organization{
+	o, svcErr := organizationService.GetOrganization(organization.Organization{
 		ResourceID: in.Organization.Id,
 	})
-	if svcError.Error != nil {
-		return nil, svcError.Error
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
-	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(o)}, nil
 }
 
 func UpdateOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
-	u, svcError := organizationService.UpdateOrganization(toOrganization(in.Organization))
-	if svcError.Error != nil {
-		return nil, svcError.Error
+	o, svcErr := organizationService.UpdateOrganization(toOrganization(in.Organization))
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
-	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(o)}, nil
 }
 
 func DeleteOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
-	u, svcError := organizationService.DeleteOrganization(organization.Organization{
+	o, svcErr := organizationService.DeleteOrganization(organization.Organization{
 		ResourceID: in.Organization.Id,
 	})
-	if svcError.Error != nil {
-		return nil, svcError.Error
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
-	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(o)}, nil
 }
 
 func AddUserToOrganization(organizationService organization.Service, ctx context.Context, in *pb.AddUserToOrganizationRequest) (*pb.OrganizationResponse, error) {

--- a/src/grpc/organization.go
+++ b/src/grpc/organization.go
@@ -6,54 +6,60 @@ import (
 	"golang.org/x/net/context"
 )
 
-func CreateOrganization(organizationService organization.Service, ctx context.Context, in *pb.CreateOrganizationRequest) (*pb.CreateOrganizationResponse, error) {
-	u, svcError := organizationService.CreateOrganization(organization.Organization{
-		Name: in.Name,
-	})
+func CreateOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
+	u, svcError := organizationService.CreateOrganization(toOrganization(in.Organization))
 	if svcError.Error != nil {
 		return nil, svcError.Error
 	}
-	return &pb.CreateOrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
 }
 
-func GetOrganization(organizationService organization.Service, ctx context.Context, in *pb.GetOrganizationRequest) (*pb.GetOrganizationResponse, error) {
+func GetOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
 	u, svcError := organizationService.GetOrganization(organization.Organization{
-		ResourceID: in.OrganizationID,
+		ResourceID: in.Organization.Id,
 	})
 	if svcError.Error != nil {
 		return nil, svcError.Error
 	}
-	return &pb.GetOrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
 }
 
-func UpdateOrganization(organizationService organization.Service, ctx context.Context, in *pb.UpdateOrganizationRequest) (*pb.UpdateOrganizationResponse, error) {
+func UpdateOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
 	u, svcError := organizationService.UpdateOrganization(toOrganization(in.Organization))
 	if svcError.Error != nil {
 		return nil, svcError.Error
 	}
-	return &pb.UpdateOrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
 }
 
-func DeleteOrganization(organizationService organization.Service, ctx context.Context, in *pb.DeleteOrganizationRequest) (*pb.DeleteOrganizationResponse, error) {
+func DeleteOrganization(organizationService organization.Service, ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
 	u, svcError := organizationService.DeleteOrganization(organization.Organization{
-		ResourceID: in.OrganizationID,
+		ResourceID: in.Organization.Id,
 	})
 	if svcError.Error != nil {
 		return nil, svcError.Error
 	}
-	return &pb.DeleteOrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+	return &pb.OrganizationResponse{Organization: toGrpcOrganization(u)}, nil
+}
+
+func AddUserToOrganization(organizationService organization.Service, ctx context.Context, in *pb.AddUserToOrganizationRequest) (*pb.OrganizationResponse, error) {
+	return nil, nil
+}
+
+func RemoveUserFromOrganization(organizationService organization.Service, ctx context.Context, in *pb.RemoveUserFromOrganizationRequest) (*pb.OrganizationResponse, error) {
+	return nil, nil
 }
 
 func toOrganization(u *pb.Organization) organization.Organization {
 	return organization.Organization{
-		ResourceID: u.OrganizationID,
+		ResourceID: u.Id,
 		Name:       u.Name,
 	}
 }
 
 func toGrpcOrganization(u *organization.Organization) *pb.Organization {
 	return &pb.Organization{
-		OrganizationID: u.ResourceID,
-		Name:           u.Name,
+		Id:   u.ResourceID,
+		Name: u.Name,
 	}
 }

--- a/src/grpc/server.go
+++ b/src/grpc/server.go
@@ -27,6 +27,30 @@ type Server struct {
 	FolderService       folder.Service
 }
 
+func (s *Server) CreateOrganization(ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
+	return CreateOrganization(s.OrganizationService, ctx, in)
+}
+
+func (s *Server) GetOrganization(ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
+	return GetOrganization(s.OrganizationService, ctx, in)
+}
+
+func (s *Server) UpdateOrganization(ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
+	return UpdateOrganization(s.OrganizationService, ctx, in)
+}
+
+func (s *Server) DeleteOrganization(ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
+	return DeleteOrganization(s.OrganizationService, ctx, in)
+}
+
+func (s *Server) AddUserToOrganization(ctx context.Context, in *pb.AddUserToOrganizationRequest) (*pb.OrganizationResponse, error) {
+	return AddUserToOrganization(s.OrganizationService, ctx, in)
+}
+
+func (s *Server) RemoveUserFromOrganization(ctx context.Context, in *pb.RemoveUserFromOrganizationRequest) (*pb.OrganizationResponse, error) {
+	return RemoveUserFromOrganization(s.OrganizationService, ctx, in)
+}
+
 func (s *Server) CreateUser(ctx context.Context, in *pb.CreateUserRequest) (*pb.CreateUserResponse, error) {
 	return CreateUser(s.UserService, ctx, in)
 }
@@ -71,6 +95,7 @@ func (s *Server) Run() {
 	// Register our services
 	pb.RegisterUserServiceServer(server, s)
 	pb.RegisterFileServiceServer(server, s)
+	pb.RegisterOrganizationServiceServer(server, s)
 
 	// Register reflection service on gRPC server.
 	reflection.Register(server)

--- a/src/grpc/server.go
+++ b/src/grpc/server.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net"
 
+	"github.com/kevinmichaelchen/neo4j-go-file-system/service"
+
 	"github.com/kevinmichaelchen/neo4j-go-file-system/file"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/folder"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/move"
@@ -27,7 +29,7 @@ type Server struct {
 	FolderService       folder.Service
 }
 
-func (s *Server) CreateOrganization(ctx context.Context, in *pb.CreateOrgRequest) (*pb.CreateOrgResponse, error) {
+func (s *Server) CreateOrganization(ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
 	return CreateOrganization(s.OrganizationService, ctx, in)
 }
 
@@ -81,6 +83,10 @@ func (s *Server) UpdateFile(ctx context.Context, in *pb.UpdateFileRequest) (*pb.
 
 func (s *Server) DeleteFile(ctx context.Context, in *pb.DeleteFileRequest) (*pb.DeleteFileResponse, error) {
 	return DeleteFile(s.FileService, ctx, in)
+}
+
+func checkForServiceError(service.Error) {
+
 }
 
 func (s *Server) Run() {

--- a/src/grpc/server.go
+++ b/src/grpc/server.go
@@ -27,7 +27,7 @@ type Server struct {
 	FolderService       folder.Service
 }
 
-func (s *Server) CreateOrganization(ctx context.Context, in *pb.OrganizationCrudRequest) (*pb.OrganizationResponse, error) {
+func (s *Server) CreateOrganization(ctx context.Context, in *pb.CreateOrgRequest) (*pb.CreateOrgResponse, error) {
 	return CreateOrganization(s.OrganizationService, ctx, in)
 }
 

--- a/src/grpc/user.go
+++ b/src/grpc/user.go
@@ -4,43 +4,44 @@ import (
 	"github.com/kevinmichaelchen/neo4j-go-file-system/pb"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/user"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/status"
 )
 
 func CreateUser(userService user.Service, ctx context.Context, in *pb.CreateUserRequest) (*pb.CreateUserResponse, error) {
-	u, svcError := userService.CreateUser(user.User{
+	u, svcErr := userService.CreateUser(user.User{
 		EmailAddress: in.User.EmailAddress,
 		FullName:     in.User.FullName,
 	})
-	if svcError.Error != nil {
-		return nil, svcError.Error
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
 	return &pb.CreateUserResponse{User: toGrpcUser(u)}, nil
 }
 
 func GetUser(userService user.Service, ctx context.Context, in *pb.GetUserRequest) (*pb.GetUserResponse, error) {
-	u, svcError := userService.GetUser(user.User{
+	u, svcErr := userService.GetUser(user.User{
 		ResourceID: in.UserID,
 	})
-	if svcError.Error != nil {
-		return nil, svcError.Error
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
 	return &pb.GetUserResponse{User: toGrpcUser(u)}, nil
 }
 
 func UpdateUser(userService user.Service, ctx context.Context, in *pb.UpdateUserRequest) (*pb.UpdateUserResponse, error) {
-	u, svcError := userService.UpdateUser(toUser(in.User))
-	if svcError.Error != nil {
-		return nil, svcError.Error
+	u, svcErr := userService.UpdateUser(toUser(in.User))
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
 	return &pb.UpdateUserResponse{User: toGrpcUser(u)}, nil
 }
 
 func DeleteUser(userService user.Service, ctx context.Context, in *pb.DeleteUserRequest) (*pb.DeleteUserResponse, error) {
-	u, svcError := userService.DeleteUser(user.User{
+	u, svcErr := userService.DeleteUser(user.User{
 		ResourceID: in.UserID,
 	})
-	if svcError.Error != nil {
-		return nil, svcError.Error
+	if svcErr != nil {
+		return nil, status.Error(svcErr.GrpcCode, svcErr.ErrorMessage)
 	}
 	return &pb.DeleteUserResponse{User: toGrpcUser(u)}, nil
 }

--- a/src/move/neo/neo.go
+++ b/src/move/neo/neo.go
@@ -2,6 +2,7 @@ package neo
 
 import (
 	"fmt"
+
 	fileNeo "github.com/kevinmichaelchen/neo4j-go-file-system/file/neo"
 	folderNeo "github.com/kevinmichaelchen/neo4j-go-file-system/folder/neo"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/move"

--- a/src/move/neo/neo.go
+++ b/src/move/neo/neo.go
@@ -2,8 +2,6 @@ package neo
 
 import (
 	"fmt"
-	"net/http"
-
 	fileNeo "github.com/kevinmichaelchen/neo4j-go-file-system/file/neo"
 	folderNeo "github.com/kevinmichaelchen/neo4j-go-file-system/folder/neo"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/move"
@@ -31,7 +29,7 @@ func (s *Service) Move(resource move.MoveOperation) (*move.MoveOperation, *servi
 		return nil, service.Internal(err)
 	}
 	if source == nil {
-		return nil, service.NewError(http.StatusNotFound, fmt.Sprintf("No file found for: %s", resource.SourceID.String()), nil)
+		return nil, service.NotFound(fmt.Sprintf("No file found for: %s", resource.SourceID.String()))
 	}
 	// TODO verify user can write to source file
 
@@ -40,7 +38,7 @@ func (s *Service) Move(resource move.MoveOperation) (*move.MoveOperation, *servi
 		return nil, service.Internal(err)
 	}
 	if dest == nil {
-		return nil, service.NewError(http.StatusNotFound, fmt.Sprintf("No folder found for: %s", resource.DestinationID.String()), nil)
+		return nil, service.NotFound(fmt.Sprintf("No folder found for: %s", resource.DestinationID.String()))
 	}
 	// TODO verify user can write to destination folder
 

--- a/src/neo/neo.go
+++ b/src/neo/neo.go
@@ -2,6 +2,7 @@ package neo
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/kevinmichaelchen/neo4j-go-file-system/service"
@@ -29,6 +30,22 @@ func createObjects(session neo4j.Session) error {
 		err    error
 		result neo4j.Result
 	)
+
+	_, err = session.WriteTransaction(func(transaction neo4j.Transaction) (interface{}, error) {
+		result, err = transaction.Run(
+			`MATCH (n) DETACH DELETE n`,
+			map[string]interface{}{})
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, result.Err()
+	})
+
+	if err != nil {
+		log.Println(err.Error())
+		log.Fatalf("Failed to delete existing data")
+	}
 
 	_, err = session.WriteTransaction(func(transaction neo4j.Transaction) (interface{}, error) {
 		result, err = transaction.Run(

--- a/src/organization/neo/neo.go
+++ b/src/organization/neo/neo.go
@@ -31,7 +31,7 @@ func (s *Service) CreateOrganization(resource organization.Organization) (*organ
 		return nil, service.Internal(err)
 	}
 	if exists {
-		return nil, service.NewError(http.StatusBadRequest, "Org already exists with that name", nil)
+		return nil, service.AlreadyExists("Org already exists with that name")
 	}
 
 	err = createOrganization(session, resource)

--- a/src/organization/neo/neo.go
+++ b/src/organization/neo/neo.go
@@ -67,6 +67,7 @@ func createOrganization(session neo4j.Session, organization organization.Organiz
 }
 
 func organizationExists(session neo4j.Session, organization organization.Organization) (bool, error) {
+	// TODO ensure IDs are unique as well
 	res, err := session.Run(`MATCH (o:Organization {name: $name}) RETURN o.name`, map[string]interface{}{"name": organization.Name})
 	if err != nil {
 		return false, err

--- a/src/organization/neo/neo.go
+++ b/src/organization/neo/neo.go
@@ -1,8 +1,6 @@
 package neo
 
 import (
-	"net/http"
-
 	"github.com/kevinmichaelchen/neo4j-go-file-system/neo"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/organization"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/service"

--- a/src/organization/neo/neo.go
+++ b/src/organization/neo/neo.go
@@ -3,7 +3,6 @@ package neo
 import (
 	"net/http"
 
-	"github.com/google/uuid"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/neo"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/organization"
 	"github.com/kevinmichaelchen/neo4j-go-file-system/service"
@@ -24,9 +23,6 @@ func (s *Service) CreateOrganization(resource organization.Organization) (*organ
 
 	session := neo.GetSession(driver)
 	defer session.Close()
-
-	// Set the ID
-	resource.ResourceID = uuid.Must(uuid.NewRandom())
 
 	// TODO validate org resource
 
@@ -84,7 +80,7 @@ func organizationExists(session neo4j.Session, organization organization.Organiz
 
 func orgToMap(organization organization.Organization) map[string]interface{} {
 	return map[string]interface{}{
-		"resource_id": organization.ResourceID.String(),
+		"resource_id": organization.ResourceID,
 		"name":        organization.Name,
 	}
 }

--- a/src/pb/organization.pb.go
+++ b/src/pb/organization.pb.go
@@ -35,7 +35,7 @@ func (m *Organization) Reset()         { *m = Organization{} }
 func (m *Organization) String() string { return proto.CompactTextString(m) }
 func (*Organization) ProtoMessage()    {}
 func (*Organization) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_5335db9296eabdb7, []int{0}
+	return fileDescriptor_organization_b4ac988073079e62, []int{0}
 }
 func (m *Organization) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Organization.Unmarshal(m, b)
@@ -80,7 +80,7 @@ func (m *OrganizationCrudRequest) Reset()         { *m = OrganizationCrudRequest
 func (m *OrganizationCrudRequest) String() string { return proto.CompactTextString(m) }
 func (*OrganizationCrudRequest) ProtoMessage()    {}
 func (*OrganizationCrudRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_5335db9296eabdb7, []int{1}
+	return fileDescriptor_organization_b4ac988073079e62, []int{1}
 }
 func (m *OrganizationCrudRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OrganizationCrudRequest.Unmarshal(m, b)
@@ -107,82 +107,6 @@ func (m *OrganizationCrudRequest) GetOrganization() *Organization {
 	return nil
 }
 
-type CreateOrgRequest struct {
-	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *CreateOrgRequest) Reset()         { *m = CreateOrgRequest{} }
-func (m *CreateOrgRequest) String() string { return proto.CompactTextString(m) }
-func (*CreateOrgRequest) ProtoMessage()    {}
-func (*CreateOrgRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_5335db9296eabdb7, []int{2}
-}
-func (m *CreateOrgRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateOrgRequest.Unmarshal(m, b)
-}
-func (m *CreateOrgRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateOrgRequest.Marshal(b, m, deterministic)
-}
-func (dst *CreateOrgRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateOrgRequest.Merge(dst, src)
-}
-func (m *CreateOrgRequest) XXX_Size() int {
-	return xxx_messageInfo_CreateOrgRequest.Size(m)
-}
-func (m *CreateOrgRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateOrgRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CreateOrgRequest proto.InternalMessageInfo
-
-func (m *CreateOrgRequest) GetOrganization() *Organization {
-	if m != nil {
-		return m.Organization
-	}
-	return nil
-}
-
-type CreateOrgResponse struct {
-	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *CreateOrgResponse) Reset()         { *m = CreateOrgResponse{} }
-func (m *CreateOrgResponse) String() string { return proto.CompactTextString(m) }
-func (*CreateOrgResponse) ProtoMessage()    {}
-func (*CreateOrgResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_5335db9296eabdb7, []int{3}
-}
-func (m *CreateOrgResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateOrgResponse.Unmarshal(m, b)
-}
-func (m *CreateOrgResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateOrgResponse.Marshal(b, m, deterministic)
-}
-func (dst *CreateOrgResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateOrgResponse.Merge(dst, src)
-}
-func (m *CreateOrgResponse) XXX_Size() int {
-	return xxx_messageInfo_CreateOrgResponse.Size(m)
-}
-func (m *CreateOrgResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateOrgResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CreateOrgResponse proto.InternalMessageInfo
-
-func (m *CreateOrgResponse) GetOrganization() *Organization {
-	if m != nil {
-		return m.Organization
-	}
-	return nil
-}
-
 type OrganizationResponse struct {
 	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
@@ -194,7 +118,7 @@ func (m *OrganizationResponse) Reset()         { *m = OrganizationResponse{} }
 func (m *OrganizationResponse) String() string { return proto.CompactTextString(m) }
 func (*OrganizationResponse) ProtoMessage()    {}
 func (*OrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_5335db9296eabdb7, []int{4}
+	return fileDescriptor_organization_b4ac988073079e62, []int{2}
 }
 func (m *OrganizationResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OrganizationResponse.Unmarshal(m, b)
@@ -233,7 +157,7 @@ func (m *AddUserToOrganizationRequest) Reset()         { *m = AddUserToOrganizat
 func (m *AddUserToOrganizationRequest) String() string { return proto.CompactTextString(m) }
 func (*AddUserToOrganizationRequest) ProtoMessage()    {}
 func (*AddUserToOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_5335db9296eabdb7, []int{5}
+	return fileDescriptor_organization_b4ac988073079e62, []int{3}
 }
 func (m *AddUserToOrganizationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AddUserToOrganizationRequest.Unmarshal(m, b)
@@ -279,7 +203,7 @@ func (m *RemoveUserFromOrganizationRequest) Reset()         { *m = RemoveUserFro
 func (m *RemoveUserFromOrganizationRequest) String() string { return proto.CompactTextString(m) }
 func (*RemoveUserFromOrganizationRequest) ProtoMessage()    {}
 func (*RemoveUserFromOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_5335db9296eabdb7, []int{6}
+	return fileDescriptor_organization_b4ac988073079e62, []int{4}
 }
 func (m *RemoveUserFromOrganizationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RemoveUserFromOrganizationRequest.Unmarshal(m, b)
@@ -316,8 +240,6 @@ func (m *RemoveUserFromOrganizationRequest) GetOrganizationID() int64 {
 func init() {
 	proto.RegisterType((*Organization)(nil), "pb.Organization")
 	proto.RegisterType((*OrganizationCrudRequest)(nil), "pb.OrganizationCrudRequest")
-	proto.RegisterType((*CreateOrgRequest)(nil), "pb.CreateOrgRequest")
-	proto.RegisterType((*CreateOrgResponse)(nil), "pb.CreateOrgResponse")
 	proto.RegisterType((*OrganizationResponse)(nil), "pb.OrganizationResponse")
 	proto.RegisterType((*AddUserToOrganizationRequest)(nil), "pb.AddUserToOrganizationRequest")
 	proto.RegisterType((*RemoveUserFromOrganizationRequest)(nil), "pb.RemoveUserFromOrganizationRequest")
@@ -335,7 +257,7 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type OrganizationServiceClient interface {
-	CreateOrganization(ctx context.Context, in *CreateOrgRequest, opts ...grpc.CallOption) (*CreateOrgResponse, error)
+	CreateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
 	GetOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
 	UpdateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
 	DeleteOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
@@ -351,8 +273,8 @@ func NewOrganizationServiceClient(cc *grpc.ClientConn) OrganizationServiceClient
 	return &organizationServiceClient{cc}
 }
 
-func (c *organizationServiceClient) CreateOrganization(ctx context.Context, in *CreateOrgRequest, opts ...grpc.CallOption) (*CreateOrgResponse, error) {
-	out := new(CreateOrgResponse)
+func (c *organizationServiceClient) CreateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
+	out := new(OrganizationResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/CreateOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -407,7 +329,7 @@ func (c *organizationServiceClient) RemoveUserFromOrganization(ctx context.Conte
 
 // OrganizationServiceServer is the server API for OrganizationService service.
 type OrganizationServiceServer interface {
-	CreateOrganization(context.Context, *CreateOrgRequest) (*CreateOrgResponse, error)
+	CreateOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
 	GetOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
 	UpdateOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
 	DeleteOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
@@ -420,7 +342,7 @@ func RegisterOrganizationServiceServer(s *grpc.Server, srv OrganizationServiceSe
 }
 
 func _OrganizationService_CreateOrganization_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CreateOrgRequest)
+	in := new(OrganizationCrudRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -432,7 +354,7 @@ func _OrganizationService_CreateOrganization_Handler(srv interface{}, ctx contex
 		FullMethod: "/pb.OrganizationService/CreateOrganization",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OrganizationServiceServer).CreateOrganization(ctx, req.(*CreateOrgRequest))
+		return srv.(OrganizationServiceServer).CreateOrganization(ctx, req.(*OrganizationCrudRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -560,29 +482,27 @@ var _OrganizationService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "organization.proto",
 }
 
-func init() { proto.RegisterFile("organization.proto", fileDescriptor_organization_5335db9296eabdb7) }
+func init() { proto.RegisterFile("organization.proto", fileDescriptor_organization_b4ac988073079e62) }
 
-var fileDescriptor_organization_5335db9296eabdb7 = []byte{
-	// 329 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x94, 0x41, 0x4f, 0x83, 0x40,
-	0x10, 0x85, 0x2d, 0x35, 0x4d, 0x1c, 0x9b, 0x5a, 0xc7, 0x56, 0x9b, 0xea, 0xa1, 0x92, 0x68, 0x7a,
-	0xea, 0xa1, 0xfa, 0x07, 0x0c, 0x44, 0xc5, 0x68, 0x48, 0x56, 0xb9, 0x6a, 0xa0, 0x3b, 0x69, 0x48,
-	0x84, 0xc5, 0x05, 0x7a, 0xf0, 0xb7, 0x7b, 0x30, 0xd0, 0xc6, 0x2e, 0xa8, 0x98, 0x88, 0xde, 0x60,
-	0x87, 0xf7, 0x3d, 0x78, 0xf3, 0x02, 0xa0, 0x90, 0x73, 0x37, 0xf4, 0x5f, 0xdd, 0xc4, 0x17, 0xe1,
-	0x24, 0x92, 0x22, 0x11, 0xa8, 0x45, 0x9e, 0x3e, 0x85, 0xb6, 0xad, 0x4c, 0xb0, 0x03, 0x9a, 0xcf,
-	0x07, 0x8d, 0x51, 0x63, 0xdc, 0x64, 0x9a, 0xcf, 0x11, 0x61, 0x33, 0x74, 0x03, 0x1a, 0x68, 0xa3,
-	0xc6, 0x78, 0x8b, 0xe5, 0xd7, 0xba, 0x0d, 0x07, 0xaa, 0xc6, 0x90, 0x29, 0x67, 0xf4, 0x92, 0x52,
-	0x9c, 0xe0, 0x39, 0xb4, 0x55, 0xa3, 0x1c, 0xb4, 0x3d, 0xed, 0x4e, 0x22, 0x6f, 0xa2, 0x4a, 0x58,
-	0xe1, 0x29, 0xfd, 0x1a, 0xba, 0x86, 0x24, 0x37, 0x21, 0x5b, 0xce, 0xeb, 0x91, 0x2c, 0xd8, 0x55,
-	0x48, 0x71, 0x24, 0xc2, 0x98, 0x7e, 0x89, 0xba, 0x85, 0x5e, 0x61, 0x5a, 0x8f, 0xf6, 0x08, 0x47,
-	0x17, 0x9c, 0x3b, 0x31, 0xc9, 0x07, 0x51, 0xc4, 0x2e, 0x3f, 0x77, 0x1f, 0x5a, 0x69, 0x4c, 0xd2,
-	0x32, 0x57, 0xd9, 0xaf, 0xee, 0xf0, 0x14, 0x3a, 0x2a, 0xc7, 0x32, 0xf3, 0x4d, 0x34, 0x59, 0xe9,
-	0x54, 0x9f, 0xc1, 0x31, 0xa3, 0x40, 0x2c, 0x28, 0xb3, 0xb8, 0x94, 0x22, 0xf8, 0x07, 0x93, 0xe9,
-	0x5b, 0x13, 0xf6, 0x54, 0xee, 0x3d, 0xc9, 0x85, 0x3f, 0x23, 0x34, 0x00, 0x3f, 0x52, 0x5f, 0x57,
-	0xa9, 0x97, 0x45, 0x52, 0xde, 0xeb, 0xb0, 0x5f, 0x3a, 0x5d, 0xa6, 0xaa, 0x6f, 0xe0, 0x0d, 0xec,
-	0x5c, 0x51, 0x52, 0x20, 0x1c, 0x96, 0x43, 0x55, 0xaa, 0x36, 0x1c, 0x7c, 0x4a, 0x7c, 0xcd, 0xba,
-	0x03, 0x74, 0x22, 0x5e, 0x7e, 0xa1, 0x3a, 0x38, 0x93, 0x9e, 0xe9, 0xaf, 0x70, 0x0e, 0xf4, 0xbf,
-	0xec, 0x02, 0x8e, 0x32, 0x51, 0x55, 0x4d, 0x2a, 0xb1, 0x4f, 0x30, 0xfc, 0xbe, 0x02, 0x78, 0x92,
-	0x29, 0x7f, 0xac, 0x48, 0x95, 0x81, 0xd7, 0xca, 0x7f, 0x1b, 0x67, 0xef, 0x01, 0x00, 0x00, 0xff,
-	0xff, 0x59, 0x4c, 0x49, 0x26, 0x4c, 0x04, 0x00, 0x00,
+var fileDescriptor_organization_b4ac988073079e62 = []byte{
+	// 304 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x93, 0xcd, 0x4e, 0xbb, 0x40,
+	0x14, 0xc5, 0xff, 0xd0, 0xa6, 0xc9, 0xff, 0xda, 0x54, 0x73, 0xfd, 0x22, 0xd5, 0x05, 0x92, 0x68,
+	0xba, 0x62, 0x81, 0xbe, 0x80, 0x29, 0xd1, 0xd4, 0x48, 0x9a, 0x8c, 0xb2, 0xd5, 0x40, 0xe7, 0xc6,
+	0x90, 0x08, 0x83, 0xc3, 0xd0, 0x85, 0x0f, 0xe0, 0x73, 0x1b, 0x90, 0xc5, 0x50, 0x15, 0x13, 0x83,
+	0x3b, 0x60, 0x38, 0xbf, 0x73, 0x3f, 0xce, 0x00, 0x0a, 0xf9, 0x14, 0x65, 0xc9, 0x6b, 0xa4, 0x12,
+	0x91, 0xb9, 0xb9, 0x14, 0x4a, 0xa0, 0x99, 0xc7, 0x8e, 0x07, 0xe3, 0xa5, 0x76, 0x82, 0x13, 0x30,
+	0x13, 0x6e, 0x19, 0xb6, 0x31, 0x1b, 0x30, 0x33, 0xe1, 0x88, 0x30, 0xcc, 0xa2, 0x94, 0x2c, 0xd3,
+	0x36, 0x66, 0xff, 0x59, 0xfd, 0xec, 0x2c, 0xe1, 0x50, 0xd7, 0xcc, 0x65, 0xc9, 0x19, 0xbd, 0x94,
+	0x54, 0x28, 0xbc, 0x80, 0xb1, 0x6e, 0x54, 0x83, 0xb6, 0xbc, 0x1d, 0x37, 0x8f, 0x5d, 0x5d, 0xc2,
+	0x5a, 0x7f, 0x39, 0xb7, 0xb0, 0xd7, 0x3a, 0xa5, 0x22, 0x17, 0x59, 0x41, 0xbf, 0xa4, 0x3d, 0xc0,
+	0xf1, 0x25, 0xe7, 0x61, 0x41, 0xf2, 0x5e, 0xb4, 0xb1, 0x1f, 0x35, 0x1e, 0xc0, 0xa8, 0x2c, 0x48,
+	0x2e, 0xfc, 0xa6, 0xcd, 0xe6, 0x0d, 0xcf, 0x60, 0xa2, 0x73, 0x16, 0x7e, 0xdd, 0xf4, 0x80, 0x6d,
+	0x7c, 0x75, 0x56, 0x70, 0xc2, 0x28, 0x15, 0x6b, 0xaa, 0x2c, 0xae, 0xa4, 0x48, 0xff, 0xc0, 0xc4,
+	0x7b, 0x1b, 0xc2, 0xae, 0xce, 0xbd, 0x23, 0xb9, 0x4e, 0x56, 0x84, 0x01, 0xe0, 0x5c, 0x52, 0xa4,
+	0xa8, 0xb5, 0xb5, 0xa3, 0xcd, 0x91, 0x68, 0x3b, 0x99, 0x5a, 0x9f, 0xe6, 0xd5, 0xcc, 0xd7, 0xf9,
+	0x87, 0x37, 0xb0, 0x7d, 0x4d, 0xaa, 0x1f, 0x56, 0x00, 0x18, 0xe6, 0xbc, 0xb7, 0xd2, 0x02, 0x40,
+	0x9f, 0x9e, 0xa9, 0x2f, 0x5c, 0x08, 0xfb, 0x5f, 0xa6, 0x02, 0xed, 0x4a, 0xd4, 0x15, 0x98, 0x4e,
+	0xec, 0x23, 0x4c, 0xbf, 0x0f, 0x03, 0x9e, 0x56, 0xca, 0x1f, 0xc3, 0xd2, 0x65, 0x10, 0x8f, 0xea,
+	0xbb, 0x7a, 0xfe, 0x1e, 0x00, 0x00, 0xff, 0xff, 0x22, 0x8a, 0x71, 0xb9, 0xc1, 0x03, 0x00, 0x00,
 }

--- a/src/pb/organization.pb.go
+++ b/src/pb/organization.pb.go
@@ -35,7 +35,7 @@ func (m *Organization) Reset()         { *m = Organization{} }
 func (m *Organization) String() string { return proto.CompactTextString(m) }
 func (*Organization) ProtoMessage()    {}
 func (*Organization) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_b4ac988073079e62, []int{0}
+	return fileDescriptor_organization_5335db9296eabdb7, []int{0}
 }
 func (m *Organization) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Organization.Unmarshal(m, b)
@@ -80,7 +80,7 @@ func (m *OrganizationCrudRequest) Reset()         { *m = OrganizationCrudRequest
 func (m *OrganizationCrudRequest) String() string { return proto.CompactTextString(m) }
 func (*OrganizationCrudRequest) ProtoMessage()    {}
 func (*OrganizationCrudRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_b4ac988073079e62, []int{1}
+	return fileDescriptor_organization_5335db9296eabdb7, []int{1}
 }
 func (m *OrganizationCrudRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OrganizationCrudRequest.Unmarshal(m, b)
@@ -107,6 +107,82 @@ func (m *OrganizationCrudRequest) GetOrganization() *Organization {
 	return nil
 }
 
+type CreateOrgRequest struct {
+	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
+}
+
+func (m *CreateOrgRequest) Reset()         { *m = CreateOrgRequest{} }
+func (m *CreateOrgRequest) String() string { return proto.CompactTextString(m) }
+func (*CreateOrgRequest) ProtoMessage()    {}
+func (*CreateOrgRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_organization_5335db9296eabdb7, []int{2}
+}
+func (m *CreateOrgRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateOrgRequest.Unmarshal(m, b)
+}
+func (m *CreateOrgRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateOrgRequest.Marshal(b, m, deterministic)
+}
+func (dst *CreateOrgRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateOrgRequest.Merge(dst, src)
+}
+func (m *CreateOrgRequest) XXX_Size() int {
+	return xxx_messageInfo_CreateOrgRequest.Size(m)
+}
+func (m *CreateOrgRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateOrgRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateOrgRequest proto.InternalMessageInfo
+
+func (m *CreateOrgRequest) GetOrganization() *Organization {
+	if m != nil {
+		return m.Organization
+	}
+	return nil
+}
+
+type CreateOrgResponse struct {
+	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
+}
+
+func (m *CreateOrgResponse) Reset()         { *m = CreateOrgResponse{} }
+func (m *CreateOrgResponse) String() string { return proto.CompactTextString(m) }
+func (*CreateOrgResponse) ProtoMessage()    {}
+func (*CreateOrgResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_organization_5335db9296eabdb7, []int{3}
+}
+func (m *CreateOrgResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateOrgResponse.Unmarshal(m, b)
+}
+func (m *CreateOrgResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateOrgResponse.Marshal(b, m, deterministic)
+}
+func (dst *CreateOrgResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateOrgResponse.Merge(dst, src)
+}
+func (m *CreateOrgResponse) XXX_Size() int {
+	return xxx_messageInfo_CreateOrgResponse.Size(m)
+}
+func (m *CreateOrgResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateOrgResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateOrgResponse proto.InternalMessageInfo
+
+func (m *CreateOrgResponse) GetOrganization() *Organization {
+	if m != nil {
+		return m.Organization
+	}
+	return nil
+}
+
 type OrganizationResponse struct {
 	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
@@ -118,7 +194,7 @@ func (m *OrganizationResponse) Reset()         { *m = OrganizationResponse{} }
 func (m *OrganizationResponse) String() string { return proto.CompactTextString(m) }
 func (*OrganizationResponse) ProtoMessage()    {}
 func (*OrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_b4ac988073079e62, []int{2}
+	return fileDescriptor_organization_5335db9296eabdb7, []int{4}
 }
 func (m *OrganizationResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OrganizationResponse.Unmarshal(m, b)
@@ -157,7 +233,7 @@ func (m *AddUserToOrganizationRequest) Reset()         { *m = AddUserToOrganizat
 func (m *AddUserToOrganizationRequest) String() string { return proto.CompactTextString(m) }
 func (*AddUserToOrganizationRequest) ProtoMessage()    {}
 func (*AddUserToOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_b4ac988073079e62, []int{3}
+	return fileDescriptor_organization_5335db9296eabdb7, []int{5}
 }
 func (m *AddUserToOrganizationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AddUserToOrganizationRequest.Unmarshal(m, b)
@@ -203,7 +279,7 @@ func (m *RemoveUserFromOrganizationRequest) Reset()         { *m = RemoveUserFro
 func (m *RemoveUserFromOrganizationRequest) String() string { return proto.CompactTextString(m) }
 func (*RemoveUserFromOrganizationRequest) ProtoMessage()    {}
 func (*RemoveUserFromOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_b4ac988073079e62, []int{4}
+	return fileDescriptor_organization_5335db9296eabdb7, []int{6}
 }
 func (m *RemoveUserFromOrganizationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RemoveUserFromOrganizationRequest.Unmarshal(m, b)
@@ -240,6 +316,8 @@ func (m *RemoveUserFromOrganizationRequest) GetOrganizationID() int64 {
 func init() {
 	proto.RegisterType((*Organization)(nil), "pb.Organization")
 	proto.RegisterType((*OrganizationCrudRequest)(nil), "pb.OrganizationCrudRequest")
+	proto.RegisterType((*CreateOrgRequest)(nil), "pb.CreateOrgRequest")
+	proto.RegisterType((*CreateOrgResponse)(nil), "pb.CreateOrgResponse")
 	proto.RegisterType((*OrganizationResponse)(nil), "pb.OrganizationResponse")
 	proto.RegisterType((*AddUserToOrganizationRequest)(nil), "pb.AddUserToOrganizationRequest")
 	proto.RegisterType((*RemoveUserFromOrganizationRequest)(nil), "pb.RemoveUserFromOrganizationRequest")
@@ -257,7 +335,7 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type OrganizationServiceClient interface {
-	CreateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
+	CreateOrganization(ctx context.Context, in *CreateOrgRequest, opts ...grpc.CallOption) (*CreateOrgResponse, error)
 	GetOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
 	UpdateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
 	DeleteOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
@@ -273,8 +351,8 @@ func NewOrganizationServiceClient(cc *grpc.ClientConn) OrganizationServiceClient
 	return &organizationServiceClient{cc}
 }
 
-func (c *organizationServiceClient) CreateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
-	out := new(OrganizationResponse)
+func (c *organizationServiceClient) CreateOrganization(ctx context.Context, in *CreateOrgRequest, opts ...grpc.CallOption) (*CreateOrgResponse, error) {
+	out := new(CreateOrgResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/CreateOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -329,7 +407,7 @@ func (c *organizationServiceClient) RemoveUserFromOrganization(ctx context.Conte
 
 // OrganizationServiceServer is the server API for OrganizationService service.
 type OrganizationServiceServer interface {
-	CreateOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
+	CreateOrganization(context.Context, *CreateOrgRequest) (*CreateOrgResponse, error)
 	GetOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
 	UpdateOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
 	DeleteOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
@@ -342,7 +420,7 @@ func RegisterOrganizationServiceServer(s *grpc.Server, srv OrganizationServiceSe
 }
 
 func _OrganizationService_CreateOrganization_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(OrganizationCrudRequest)
+	in := new(CreateOrgRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -354,7 +432,7 @@ func _OrganizationService_CreateOrganization_Handler(srv interface{}, ctx contex
 		FullMethod: "/pb.OrganizationService/CreateOrganization",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OrganizationServiceServer).CreateOrganization(ctx, req.(*OrganizationCrudRequest))
+		return srv.(OrganizationServiceServer).CreateOrganization(ctx, req.(*CreateOrgRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -482,27 +560,29 @@ var _OrganizationService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "organization.proto",
 }
 
-func init() { proto.RegisterFile("organization.proto", fileDescriptor_organization_b4ac988073079e62) }
+func init() { proto.RegisterFile("organization.proto", fileDescriptor_organization_5335db9296eabdb7) }
 
-var fileDescriptor_organization_b4ac988073079e62 = []byte{
-	// 304 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x93, 0xcd, 0x4e, 0xbb, 0x40,
-	0x14, 0xc5, 0xff, 0xd0, 0xa6, 0xc9, 0xff, 0xda, 0x54, 0x73, 0xfd, 0x22, 0xd5, 0x05, 0x92, 0x68,
-	0xba, 0x62, 0x81, 0xbe, 0x80, 0x29, 0xd1, 0xd4, 0x48, 0x9a, 0x8c, 0xb2, 0xd5, 0x40, 0xe7, 0xc6,
-	0x90, 0x08, 0x83, 0xc3, 0xd0, 0x85, 0x0f, 0xe0, 0x73, 0x1b, 0x90, 0xc5, 0x50, 0x15, 0x13, 0x83,
-	0x3b, 0x60, 0x38, 0xbf, 0x73, 0x3f, 0xce, 0x00, 0x0a, 0xf9, 0x14, 0x65, 0xc9, 0x6b, 0xa4, 0x12,
-	0x91, 0xb9, 0xb9, 0x14, 0x4a, 0xa0, 0x99, 0xc7, 0x8e, 0x07, 0xe3, 0xa5, 0x76, 0x82, 0x13, 0x30,
-	0x13, 0x6e, 0x19, 0xb6, 0x31, 0x1b, 0x30, 0x33, 0xe1, 0x88, 0x30, 0xcc, 0xa2, 0x94, 0x2c, 0xd3,
-	0x36, 0x66, 0xff, 0x59, 0xfd, 0xec, 0x2c, 0xe1, 0x50, 0xd7, 0xcc, 0x65, 0xc9, 0x19, 0xbd, 0x94,
-	0x54, 0x28, 0xbc, 0x80, 0xb1, 0x6e, 0x54, 0x83, 0xb6, 0xbc, 0x1d, 0x37, 0x8f, 0x5d, 0x5d, 0xc2,
-	0x5a, 0x7f, 0x39, 0xb7, 0xb0, 0xd7, 0x3a, 0xa5, 0x22, 0x17, 0x59, 0x41, 0xbf, 0xa4, 0x3d, 0xc0,
-	0xf1, 0x25, 0xe7, 0x61, 0x41, 0xf2, 0x5e, 0xb4, 0xb1, 0x1f, 0x35, 0x1e, 0xc0, 0xa8, 0x2c, 0x48,
-	0x2e, 0xfc, 0xa6, 0xcd, 0xe6, 0x0d, 0xcf, 0x60, 0xa2, 0x73, 0x16, 0x7e, 0xdd, 0xf4, 0x80, 0x6d,
-	0x7c, 0x75, 0x56, 0x70, 0xc2, 0x28, 0x15, 0x6b, 0xaa, 0x2c, 0xae, 0xa4, 0x48, 0xff, 0xc0, 0xc4,
-	0x7b, 0x1b, 0xc2, 0xae, 0xce, 0xbd, 0x23, 0xb9, 0x4e, 0x56, 0x84, 0x01, 0xe0, 0x5c, 0x52, 0xa4,
-	0xa8, 0xb5, 0xb5, 0xa3, 0xcd, 0x91, 0x68, 0x3b, 0x99, 0x5a, 0x9f, 0xe6, 0xd5, 0xcc, 0xd7, 0xf9,
-	0x87, 0x37, 0xb0, 0x7d, 0x4d, 0xaa, 0x1f, 0x56, 0x00, 0x18, 0xe6, 0xbc, 0xb7, 0xd2, 0x02, 0x40,
-	0x9f, 0x9e, 0xa9, 0x2f, 0x5c, 0x08, 0xfb, 0x5f, 0xa6, 0x02, 0xed, 0x4a, 0xd4, 0x15, 0x98, 0x4e,
-	0xec, 0x23, 0x4c, 0xbf, 0x0f, 0x03, 0x9e, 0x56, 0xca, 0x1f, 0xc3, 0xd2, 0x65, 0x10, 0x8f, 0xea,
-	0xbb, 0x7a, 0xfe, 0x1e, 0x00, 0x00, 0xff, 0xff, 0x22, 0x8a, 0x71, 0xb9, 0xc1, 0x03, 0x00, 0x00,
+var fileDescriptor_organization_5335db9296eabdb7 = []byte{
+	// 329 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x94, 0x41, 0x4f, 0x83, 0x40,
+	0x10, 0x85, 0x2d, 0x35, 0x4d, 0x1c, 0x9b, 0x5a, 0xc7, 0x56, 0x9b, 0xea, 0xa1, 0x92, 0x68, 0x7a,
+	0xea, 0xa1, 0xfa, 0x07, 0x0c, 0x44, 0xc5, 0x68, 0x48, 0x56, 0xb9, 0x6a, 0xa0, 0x3b, 0x69, 0x48,
+	0x84, 0xc5, 0x05, 0x7a, 0xf0, 0xb7, 0x7b, 0x30, 0xd0, 0xc6, 0x2e, 0xa8, 0x98, 0x88, 0xde, 0x60,
+	0x87, 0xf7, 0x3d, 0x78, 0xf3, 0x02, 0xa0, 0x90, 0x73, 0x37, 0xf4, 0x5f, 0xdd, 0xc4, 0x17, 0xe1,
+	0x24, 0x92, 0x22, 0x11, 0xa8, 0x45, 0x9e, 0x3e, 0x85, 0xb6, 0xad, 0x4c, 0xb0, 0x03, 0x9a, 0xcf,
+	0x07, 0x8d, 0x51, 0x63, 0xdc, 0x64, 0x9a, 0xcf, 0x11, 0x61, 0x33, 0x74, 0x03, 0x1a, 0x68, 0xa3,
+	0xc6, 0x78, 0x8b, 0xe5, 0xd7, 0xba, 0x0d, 0x07, 0xaa, 0xc6, 0x90, 0x29, 0x67, 0xf4, 0x92, 0x52,
+	0x9c, 0xe0, 0x39, 0xb4, 0x55, 0xa3, 0x1c, 0xb4, 0x3d, 0xed, 0x4e, 0x22, 0x6f, 0xa2, 0x4a, 0x58,
+	0xe1, 0x29, 0xfd, 0x1a, 0xba, 0x86, 0x24, 0x37, 0x21, 0x5b, 0xce, 0xeb, 0x91, 0x2c, 0xd8, 0x55,
+	0x48, 0x71, 0x24, 0xc2, 0x98, 0x7e, 0x89, 0xba, 0x85, 0x5e, 0x61, 0x5a, 0x8f, 0xf6, 0x08, 0x47,
+	0x17, 0x9c, 0x3b, 0x31, 0xc9, 0x07, 0x51, 0xc4, 0x2e, 0x3f, 0x77, 0x1f, 0x5a, 0x69, 0x4c, 0xd2,
+	0x32, 0x57, 0xd9, 0xaf, 0xee, 0xf0, 0x14, 0x3a, 0x2a, 0xc7, 0x32, 0xf3, 0x4d, 0x34, 0x59, 0xe9,
+	0x54, 0x9f, 0xc1, 0x31, 0xa3, 0x40, 0x2c, 0x28, 0xb3, 0xb8, 0x94, 0x22, 0xf8, 0x07, 0x93, 0xe9,
+	0x5b, 0x13, 0xf6, 0x54, 0xee, 0x3d, 0xc9, 0x85, 0x3f, 0x23, 0x34, 0x00, 0x3f, 0x52, 0x5f, 0x57,
+	0xa9, 0x97, 0x45, 0x52, 0xde, 0xeb, 0xb0, 0x5f, 0x3a, 0x5d, 0xa6, 0xaa, 0x6f, 0xe0, 0x0d, 0xec,
+	0x5c, 0x51, 0x52, 0x20, 0x1c, 0x96, 0x43, 0x55, 0xaa, 0x36, 0x1c, 0x7c, 0x4a, 0x7c, 0xcd, 0xba,
+	0x03, 0x74, 0x22, 0x5e, 0x7e, 0xa1, 0x3a, 0x38, 0x93, 0x9e, 0xe9, 0xaf, 0x70, 0x0e, 0xf4, 0xbf,
+	0xec, 0x02, 0x8e, 0x32, 0x51, 0x55, 0x4d, 0x2a, 0xb1, 0x4f, 0x30, 0xfc, 0xbe, 0x02, 0x78, 0x92,
+	0x29, 0x7f, 0xac, 0x48, 0x95, 0x81, 0xd7, 0xca, 0x7f, 0x1b, 0x67, 0xef, 0x01, 0x00, 0x00, 0xff,
+	0xff, 0x59, 0x4c, 0x49, 0x26, 0x4c, 0x04, 0x00, 0x00,
 }

--- a/src/pb/organization.pb.go
+++ b/src/pb/organization.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type Organization struct {
-	OrganizationID       int64    `protobuf:"varint,1,opt,name=organizationID,proto3" json:"organizationID,omitempty"`
+	Id                   int64    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	Name                 string   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -35,7 +35,7 @@ func (m *Organization) Reset()         { *m = Organization{} }
 func (m *Organization) String() string { return proto.CompactTextString(m) }
 func (*Organization) ProtoMessage()    {}
 func (*Organization) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{0}
+	return fileDescriptor_organization_b4ac988073079e62, []int{0}
 }
 func (m *Organization) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Organization.Unmarshal(m, b)
@@ -55,9 +55,9 @@ func (m *Organization) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Organization proto.InternalMessageInfo
 
-func (m *Organization) GetOrganizationID() int64 {
+func (m *Organization) GetId() int64 {
 	if m != nil {
-		return m.OrganizationID
+		return m.Id
 	}
 	return 0
 }
@@ -69,304 +69,76 @@ func (m *Organization) GetName() string {
 	return ""
 }
 
-type CreateOrganizationRequest struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *CreateOrganizationRequest) Reset()         { *m = CreateOrganizationRequest{} }
-func (m *CreateOrganizationRequest) String() string { return proto.CompactTextString(m) }
-func (*CreateOrganizationRequest) ProtoMessage()    {}
-func (*CreateOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{1}
-}
-func (m *CreateOrganizationRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateOrganizationRequest.Unmarshal(m, b)
-}
-func (m *CreateOrganizationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateOrganizationRequest.Marshal(b, m, deterministic)
-}
-func (dst *CreateOrganizationRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateOrganizationRequest.Merge(dst, src)
-}
-func (m *CreateOrganizationRequest) XXX_Size() int {
-	return xxx_messageInfo_CreateOrganizationRequest.Size(m)
-}
-func (m *CreateOrganizationRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateOrganizationRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CreateOrganizationRequest proto.InternalMessageInfo
-
-func (m *CreateOrganizationRequest) GetName() string {
-	if m != nil {
-		return m.Name
-	}
-	return ""
-}
-
-type CreateOrganizationResponse struct {
+type OrganizationCrudRequest struct {
 	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *CreateOrganizationResponse) Reset()         { *m = CreateOrganizationResponse{} }
-func (m *CreateOrganizationResponse) String() string { return proto.CompactTextString(m) }
-func (*CreateOrganizationResponse) ProtoMessage()    {}
-func (*CreateOrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{2}
+func (m *OrganizationCrudRequest) Reset()         { *m = OrganizationCrudRequest{} }
+func (m *OrganizationCrudRequest) String() string { return proto.CompactTextString(m) }
+func (*OrganizationCrudRequest) ProtoMessage()    {}
+func (*OrganizationCrudRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_organization_b4ac988073079e62, []int{1}
 }
-func (m *CreateOrganizationResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateOrganizationResponse.Unmarshal(m, b)
+func (m *OrganizationCrudRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_OrganizationCrudRequest.Unmarshal(m, b)
 }
-func (m *CreateOrganizationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateOrganizationResponse.Marshal(b, m, deterministic)
+func (m *OrganizationCrudRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_OrganizationCrudRequest.Marshal(b, m, deterministic)
 }
-func (dst *CreateOrganizationResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateOrganizationResponse.Merge(dst, src)
+func (dst *OrganizationCrudRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OrganizationCrudRequest.Merge(dst, src)
 }
-func (m *CreateOrganizationResponse) XXX_Size() int {
-	return xxx_messageInfo_CreateOrganizationResponse.Size(m)
+func (m *OrganizationCrudRequest) XXX_Size() int {
+	return xxx_messageInfo_OrganizationCrudRequest.Size(m)
 }
-func (m *CreateOrganizationResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateOrganizationResponse.DiscardUnknown(m)
+func (m *OrganizationCrudRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_OrganizationCrudRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CreateOrganizationResponse proto.InternalMessageInfo
+var xxx_messageInfo_OrganizationCrudRequest proto.InternalMessageInfo
 
-func (m *CreateOrganizationResponse) GetOrganization() *Organization {
+func (m *OrganizationCrudRequest) GetOrganization() *Organization {
 	if m != nil {
 		return m.Organization
 	}
 	return nil
 }
 
-type GetOrganizationRequest struct {
-	OrganizationID       int64    `protobuf:"varint,1,opt,name=organizationID,proto3" json:"organizationID,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *GetOrganizationRequest) Reset()         { *m = GetOrganizationRequest{} }
-func (m *GetOrganizationRequest) String() string { return proto.CompactTextString(m) }
-func (*GetOrganizationRequest) ProtoMessage()    {}
-func (*GetOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{3}
-}
-func (m *GetOrganizationRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetOrganizationRequest.Unmarshal(m, b)
-}
-func (m *GetOrganizationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetOrganizationRequest.Marshal(b, m, deterministic)
-}
-func (dst *GetOrganizationRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetOrganizationRequest.Merge(dst, src)
-}
-func (m *GetOrganizationRequest) XXX_Size() int {
-	return xxx_messageInfo_GetOrganizationRequest.Size(m)
-}
-func (m *GetOrganizationRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetOrganizationRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetOrganizationRequest proto.InternalMessageInfo
-
-func (m *GetOrganizationRequest) GetOrganizationID() int64 {
-	if m != nil {
-		return m.OrganizationID
-	}
-	return 0
-}
-
-type GetOrganizationResponse struct {
+type OrganizationResponse struct {
 	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *GetOrganizationResponse) Reset()         { *m = GetOrganizationResponse{} }
-func (m *GetOrganizationResponse) String() string { return proto.CompactTextString(m) }
-func (*GetOrganizationResponse) ProtoMessage()    {}
-func (*GetOrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{4}
+func (m *OrganizationResponse) Reset()         { *m = OrganizationResponse{} }
+func (m *OrganizationResponse) String() string { return proto.CompactTextString(m) }
+func (*OrganizationResponse) ProtoMessage()    {}
+func (*OrganizationResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_organization_b4ac988073079e62, []int{2}
 }
-func (m *GetOrganizationResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetOrganizationResponse.Unmarshal(m, b)
+func (m *OrganizationResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_OrganizationResponse.Unmarshal(m, b)
 }
-func (m *GetOrganizationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetOrganizationResponse.Marshal(b, m, deterministic)
+func (m *OrganizationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_OrganizationResponse.Marshal(b, m, deterministic)
 }
-func (dst *GetOrganizationResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetOrganizationResponse.Merge(dst, src)
+func (dst *OrganizationResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OrganizationResponse.Merge(dst, src)
 }
-func (m *GetOrganizationResponse) XXX_Size() int {
-	return xxx_messageInfo_GetOrganizationResponse.Size(m)
+func (m *OrganizationResponse) XXX_Size() int {
+	return xxx_messageInfo_OrganizationResponse.Size(m)
 }
-func (m *GetOrganizationResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetOrganizationResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetOrganizationResponse proto.InternalMessageInfo
-
-func (m *GetOrganizationResponse) GetOrganization() *Organization {
-	if m != nil {
-		return m.Organization
-	}
-	return nil
+func (m *OrganizationResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_OrganizationResponse.DiscardUnknown(m)
 }
 
-type UpdateOrganizationRequest struct {
-	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
+var xxx_messageInfo_OrganizationResponse proto.InternalMessageInfo
 
-func (m *UpdateOrganizationRequest) Reset()         { *m = UpdateOrganizationRequest{} }
-func (m *UpdateOrganizationRequest) String() string { return proto.CompactTextString(m) }
-func (*UpdateOrganizationRequest) ProtoMessage()    {}
-func (*UpdateOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{5}
-}
-func (m *UpdateOrganizationRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateOrganizationRequest.Unmarshal(m, b)
-}
-func (m *UpdateOrganizationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateOrganizationRequest.Marshal(b, m, deterministic)
-}
-func (dst *UpdateOrganizationRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateOrganizationRequest.Merge(dst, src)
-}
-func (m *UpdateOrganizationRequest) XXX_Size() int {
-	return xxx_messageInfo_UpdateOrganizationRequest.Size(m)
-}
-func (m *UpdateOrganizationRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateOrganizationRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_UpdateOrganizationRequest proto.InternalMessageInfo
-
-func (m *UpdateOrganizationRequest) GetOrganization() *Organization {
-	if m != nil {
-		return m.Organization
-	}
-	return nil
-}
-
-type UpdateOrganizationResponse struct {
-	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *UpdateOrganizationResponse) Reset()         { *m = UpdateOrganizationResponse{} }
-func (m *UpdateOrganizationResponse) String() string { return proto.CompactTextString(m) }
-func (*UpdateOrganizationResponse) ProtoMessage()    {}
-func (*UpdateOrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{6}
-}
-func (m *UpdateOrganizationResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateOrganizationResponse.Unmarshal(m, b)
-}
-func (m *UpdateOrganizationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateOrganizationResponse.Marshal(b, m, deterministic)
-}
-func (dst *UpdateOrganizationResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateOrganizationResponse.Merge(dst, src)
-}
-func (m *UpdateOrganizationResponse) XXX_Size() int {
-	return xxx_messageInfo_UpdateOrganizationResponse.Size(m)
-}
-func (m *UpdateOrganizationResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateOrganizationResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_UpdateOrganizationResponse proto.InternalMessageInfo
-
-func (m *UpdateOrganizationResponse) GetOrganization() *Organization {
-	if m != nil {
-		return m.Organization
-	}
-	return nil
-}
-
-type DeleteOrganizationRequest struct {
-	OrganizationID       int64    `protobuf:"varint,1,opt,name=organizationID,proto3" json:"organizationID,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *DeleteOrganizationRequest) Reset()         { *m = DeleteOrganizationRequest{} }
-func (m *DeleteOrganizationRequest) String() string { return proto.CompactTextString(m) }
-func (*DeleteOrganizationRequest) ProtoMessage()    {}
-func (*DeleteOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{7}
-}
-func (m *DeleteOrganizationRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteOrganizationRequest.Unmarshal(m, b)
-}
-func (m *DeleteOrganizationRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteOrganizationRequest.Marshal(b, m, deterministic)
-}
-func (dst *DeleteOrganizationRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteOrganizationRequest.Merge(dst, src)
-}
-func (m *DeleteOrganizationRequest) XXX_Size() int {
-	return xxx_messageInfo_DeleteOrganizationRequest.Size(m)
-}
-func (m *DeleteOrganizationRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteOrganizationRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_DeleteOrganizationRequest proto.InternalMessageInfo
-
-func (m *DeleteOrganizationRequest) GetOrganizationID() int64 {
-	if m != nil {
-		return m.OrganizationID
-	}
-	return 0
-}
-
-type DeleteOrganizationResponse struct {
-	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *DeleteOrganizationResponse) Reset()         { *m = DeleteOrganizationResponse{} }
-func (m *DeleteOrganizationResponse) String() string { return proto.CompactTextString(m) }
-func (*DeleteOrganizationResponse) ProtoMessage()    {}
-func (*DeleteOrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{8}
-}
-func (m *DeleteOrganizationResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteOrganizationResponse.Unmarshal(m, b)
-}
-func (m *DeleteOrganizationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteOrganizationResponse.Marshal(b, m, deterministic)
-}
-func (dst *DeleteOrganizationResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteOrganizationResponse.Merge(dst, src)
-}
-func (m *DeleteOrganizationResponse) XXX_Size() int {
-	return xxx_messageInfo_DeleteOrganizationResponse.Size(m)
-}
-func (m *DeleteOrganizationResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteOrganizationResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_DeleteOrganizationResponse proto.InternalMessageInfo
-
-func (m *DeleteOrganizationResponse) GetOrganization() *Organization {
+func (m *OrganizationResponse) GetOrganization() *Organization {
 	if m != nil {
 		return m.Organization
 	}
@@ -385,7 +157,7 @@ func (m *AddUserToOrganizationRequest) Reset()         { *m = AddUserToOrganizat
 func (m *AddUserToOrganizationRequest) String() string { return proto.CompactTextString(m) }
 func (*AddUserToOrganizationRequest) ProtoMessage()    {}
 func (*AddUserToOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{9}
+	return fileDescriptor_organization_b4ac988073079e62, []int{3}
 }
 func (m *AddUserToOrganizationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AddUserToOrganizationRequest.Unmarshal(m, b)
@@ -419,44 +191,6 @@ func (m *AddUserToOrganizationRequest) GetOrganizationID() int64 {
 	return 0
 }
 
-type AddUserToOrganizationResponse struct {
-	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *AddUserToOrganizationResponse) Reset()         { *m = AddUserToOrganizationResponse{} }
-func (m *AddUserToOrganizationResponse) String() string { return proto.CompactTextString(m) }
-func (*AddUserToOrganizationResponse) ProtoMessage()    {}
-func (*AddUserToOrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{10}
-}
-func (m *AddUserToOrganizationResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_AddUserToOrganizationResponse.Unmarshal(m, b)
-}
-func (m *AddUserToOrganizationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_AddUserToOrganizationResponse.Marshal(b, m, deterministic)
-}
-func (dst *AddUserToOrganizationResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AddUserToOrganizationResponse.Merge(dst, src)
-}
-func (m *AddUserToOrganizationResponse) XXX_Size() int {
-	return xxx_messageInfo_AddUserToOrganizationResponse.Size(m)
-}
-func (m *AddUserToOrganizationResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_AddUserToOrganizationResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_AddUserToOrganizationResponse proto.InternalMessageInfo
-
-func (m *AddUserToOrganizationResponse) GetOrganization() *Organization {
-	if m != nil {
-		return m.Organization
-	}
-	return nil
-}
-
 type RemoveUserFromOrganizationRequest struct {
 	UserID               int64    `protobuf:"varint,1,opt,name=userID,proto3" json:"userID,omitempty"`
 	OrganizationID       int64    `protobuf:"varint,2,opt,name=organizationID,proto3" json:"organizationID,omitempty"`
@@ -469,7 +203,7 @@ func (m *RemoveUserFromOrganizationRequest) Reset()         { *m = RemoveUserFro
 func (m *RemoveUserFromOrganizationRequest) String() string { return proto.CompactTextString(m) }
 func (*RemoveUserFromOrganizationRequest) ProtoMessage()    {}
 func (*RemoveUserFromOrganizationRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{11}
+	return fileDescriptor_organization_b4ac988073079e62, []int{4}
 }
 func (m *RemoveUserFromOrganizationRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RemoveUserFromOrganizationRequest.Unmarshal(m, b)
@@ -503,58 +237,12 @@ func (m *RemoveUserFromOrganizationRequest) GetOrganizationID() int64 {
 	return 0
 }
 
-type RemoveUserFromOrganizationResponse struct {
-	Organization         *Organization `protobuf:"bytes,1,opt,name=organization,proto3" json:"organization,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *RemoveUserFromOrganizationResponse) Reset()         { *m = RemoveUserFromOrganizationResponse{} }
-func (m *RemoveUserFromOrganizationResponse) String() string { return proto.CompactTextString(m) }
-func (*RemoveUserFromOrganizationResponse) ProtoMessage()    {}
-func (*RemoveUserFromOrganizationResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_organization_ab0b4e5ae001623e, []int{12}
-}
-func (m *RemoveUserFromOrganizationResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_RemoveUserFromOrganizationResponse.Unmarshal(m, b)
-}
-func (m *RemoveUserFromOrganizationResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_RemoveUserFromOrganizationResponse.Marshal(b, m, deterministic)
-}
-func (dst *RemoveUserFromOrganizationResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RemoveUserFromOrganizationResponse.Merge(dst, src)
-}
-func (m *RemoveUserFromOrganizationResponse) XXX_Size() int {
-	return xxx_messageInfo_RemoveUserFromOrganizationResponse.Size(m)
-}
-func (m *RemoveUserFromOrganizationResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_RemoveUserFromOrganizationResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_RemoveUserFromOrganizationResponse proto.InternalMessageInfo
-
-func (m *RemoveUserFromOrganizationResponse) GetOrganization() *Organization {
-	if m != nil {
-		return m.Organization
-	}
-	return nil
-}
-
 func init() {
 	proto.RegisterType((*Organization)(nil), "pb.Organization")
-	proto.RegisterType((*CreateOrganizationRequest)(nil), "pb.CreateOrganizationRequest")
-	proto.RegisterType((*CreateOrganizationResponse)(nil), "pb.CreateOrganizationResponse")
-	proto.RegisterType((*GetOrganizationRequest)(nil), "pb.GetOrganizationRequest")
-	proto.RegisterType((*GetOrganizationResponse)(nil), "pb.GetOrganizationResponse")
-	proto.RegisterType((*UpdateOrganizationRequest)(nil), "pb.UpdateOrganizationRequest")
-	proto.RegisterType((*UpdateOrganizationResponse)(nil), "pb.UpdateOrganizationResponse")
-	proto.RegisterType((*DeleteOrganizationRequest)(nil), "pb.DeleteOrganizationRequest")
-	proto.RegisterType((*DeleteOrganizationResponse)(nil), "pb.DeleteOrganizationResponse")
+	proto.RegisterType((*OrganizationCrudRequest)(nil), "pb.OrganizationCrudRequest")
+	proto.RegisterType((*OrganizationResponse)(nil), "pb.OrganizationResponse")
 	proto.RegisterType((*AddUserToOrganizationRequest)(nil), "pb.AddUserToOrganizationRequest")
-	proto.RegisterType((*AddUserToOrganizationResponse)(nil), "pb.AddUserToOrganizationResponse")
 	proto.RegisterType((*RemoveUserFromOrganizationRequest)(nil), "pb.RemoveUserFromOrganizationRequest")
-	proto.RegisterType((*RemoveUserFromOrganizationResponse)(nil), "pb.RemoveUserFromOrganizationResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -569,12 +257,12 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type OrganizationServiceClient interface {
-	CreateOrganization(ctx context.Context, in *CreateOrganizationRequest, opts ...grpc.CallOption) (*CreateOrganizationResponse, error)
-	GetOrganization(ctx context.Context, in *GetOrganizationRequest, opts ...grpc.CallOption) (*GetOrganizationResponse, error)
-	UpdateOrganization(ctx context.Context, in *UpdateOrganizationRequest, opts ...grpc.CallOption) (*UpdateOrganizationResponse, error)
-	DeleteOrganization(ctx context.Context, in *DeleteOrganizationRequest, opts ...grpc.CallOption) (*DeleteOrganizationResponse, error)
-	AddUserToOrganization(ctx context.Context, in *AddUserToOrganizationRequest, opts ...grpc.CallOption) (*AddUserToOrganizationResponse, error)
-	RemoveUserFromOrganization(ctx context.Context, in *RemoveUserFromOrganizationRequest, opts ...grpc.CallOption) (*RemoveUserFromOrganizationResponse, error)
+	CreateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
+	GetOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
+	UpdateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
+	DeleteOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
+	AddUserToOrganization(ctx context.Context, in *AddUserToOrganizationRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
+	RemoveUserFromOrganization(ctx context.Context, in *RemoveUserFromOrganizationRequest, opts ...grpc.CallOption) (*OrganizationResponse, error)
 }
 
 type organizationServiceClient struct {
@@ -585,8 +273,8 @@ func NewOrganizationServiceClient(cc *grpc.ClientConn) OrganizationServiceClient
 	return &organizationServiceClient{cc}
 }
 
-func (c *organizationServiceClient) CreateOrganization(ctx context.Context, in *CreateOrganizationRequest, opts ...grpc.CallOption) (*CreateOrganizationResponse, error) {
-	out := new(CreateOrganizationResponse)
+func (c *organizationServiceClient) CreateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
+	out := new(OrganizationResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/CreateOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -594,8 +282,8 @@ func (c *organizationServiceClient) CreateOrganization(ctx context.Context, in *
 	return out, nil
 }
 
-func (c *organizationServiceClient) GetOrganization(ctx context.Context, in *GetOrganizationRequest, opts ...grpc.CallOption) (*GetOrganizationResponse, error) {
-	out := new(GetOrganizationResponse)
+func (c *organizationServiceClient) GetOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
+	out := new(OrganizationResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/GetOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -603,8 +291,8 @@ func (c *organizationServiceClient) GetOrganization(ctx context.Context, in *Get
 	return out, nil
 }
 
-func (c *organizationServiceClient) UpdateOrganization(ctx context.Context, in *UpdateOrganizationRequest, opts ...grpc.CallOption) (*UpdateOrganizationResponse, error) {
-	out := new(UpdateOrganizationResponse)
+func (c *organizationServiceClient) UpdateOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
+	out := new(OrganizationResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/UpdateOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -612,8 +300,8 @@ func (c *organizationServiceClient) UpdateOrganization(ctx context.Context, in *
 	return out, nil
 }
 
-func (c *organizationServiceClient) DeleteOrganization(ctx context.Context, in *DeleteOrganizationRequest, opts ...grpc.CallOption) (*DeleteOrganizationResponse, error) {
-	out := new(DeleteOrganizationResponse)
+func (c *organizationServiceClient) DeleteOrganization(ctx context.Context, in *OrganizationCrudRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
+	out := new(OrganizationResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/DeleteOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -621,8 +309,8 @@ func (c *organizationServiceClient) DeleteOrganization(ctx context.Context, in *
 	return out, nil
 }
 
-func (c *organizationServiceClient) AddUserToOrganization(ctx context.Context, in *AddUserToOrganizationRequest, opts ...grpc.CallOption) (*AddUserToOrganizationResponse, error) {
-	out := new(AddUserToOrganizationResponse)
+func (c *organizationServiceClient) AddUserToOrganization(ctx context.Context, in *AddUserToOrganizationRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
+	out := new(OrganizationResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/AddUserToOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -630,8 +318,8 @@ func (c *organizationServiceClient) AddUserToOrganization(ctx context.Context, i
 	return out, nil
 }
 
-func (c *organizationServiceClient) RemoveUserFromOrganization(ctx context.Context, in *RemoveUserFromOrganizationRequest, opts ...grpc.CallOption) (*RemoveUserFromOrganizationResponse, error) {
-	out := new(RemoveUserFromOrganizationResponse)
+func (c *organizationServiceClient) RemoveUserFromOrganization(ctx context.Context, in *RemoveUserFromOrganizationRequest, opts ...grpc.CallOption) (*OrganizationResponse, error) {
+	out := new(OrganizationResponse)
 	err := c.cc.Invoke(ctx, "/pb.OrganizationService/RemoveUserFromOrganization", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -641,12 +329,12 @@ func (c *organizationServiceClient) RemoveUserFromOrganization(ctx context.Conte
 
 // OrganizationServiceServer is the server API for OrganizationService service.
 type OrganizationServiceServer interface {
-	CreateOrganization(context.Context, *CreateOrganizationRequest) (*CreateOrganizationResponse, error)
-	GetOrganization(context.Context, *GetOrganizationRequest) (*GetOrganizationResponse, error)
-	UpdateOrganization(context.Context, *UpdateOrganizationRequest) (*UpdateOrganizationResponse, error)
-	DeleteOrganization(context.Context, *DeleteOrganizationRequest) (*DeleteOrganizationResponse, error)
-	AddUserToOrganization(context.Context, *AddUserToOrganizationRequest) (*AddUserToOrganizationResponse, error)
-	RemoveUserFromOrganization(context.Context, *RemoveUserFromOrganizationRequest) (*RemoveUserFromOrganizationResponse, error)
+	CreateOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
+	GetOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
+	UpdateOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
+	DeleteOrganization(context.Context, *OrganizationCrudRequest) (*OrganizationResponse, error)
+	AddUserToOrganization(context.Context, *AddUserToOrganizationRequest) (*OrganizationResponse, error)
+	RemoveUserFromOrganization(context.Context, *RemoveUserFromOrganizationRequest) (*OrganizationResponse, error)
 }
 
 func RegisterOrganizationServiceServer(s *grpc.Server, srv OrganizationServiceServer) {
@@ -654,7 +342,7 @@ func RegisterOrganizationServiceServer(s *grpc.Server, srv OrganizationServiceSe
 }
 
 func _OrganizationService_CreateOrganization_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CreateOrganizationRequest)
+	in := new(OrganizationCrudRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -666,13 +354,13 @@ func _OrganizationService_CreateOrganization_Handler(srv interface{}, ctx contex
 		FullMethod: "/pb.OrganizationService/CreateOrganization",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OrganizationServiceServer).CreateOrganization(ctx, req.(*CreateOrganizationRequest))
+		return srv.(OrganizationServiceServer).CreateOrganization(ctx, req.(*OrganizationCrudRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OrganizationService_GetOrganization_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetOrganizationRequest)
+	in := new(OrganizationCrudRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -684,13 +372,13 @@ func _OrganizationService_GetOrganization_Handler(srv interface{}, ctx context.C
 		FullMethod: "/pb.OrganizationService/GetOrganization",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OrganizationServiceServer).GetOrganization(ctx, req.(*GetOrganizationRequest))
+		return srv.(OrganizationServiceServer).GetOrganization(ctx, req.(*OrganizationCrudRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OrganizationService_UpdateOrganization_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(UpdateOrganizationRequest)
+	in := new(OrganizationCrudRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -702,13 +390,13 @@ func _OrganizationService_UpdateOrganization_Handler(srv interface{}, ctx contex
 		FullMethod: "/pb.OrganizationService/UpdateOrganization",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OrganizationServiceServer).UpdateOrganization(ctx, req.(*UpdateOrganizationRequest))
+		return srv.(OrganizationServiceServer).UpdateOrganization(ctx, req.(*OrganizationCrudRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OrganizationService_DeleteOrganization_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeleteOrganizationRequest)
+	in := new(OrganizationCrudRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -720,7 +408,7 @@ func _OrganizationService_DeleteOrganization_Handler(srv interface{}, ctx contex
 		FullMethod: "/pb.OrganizationService/DeleteOrganization",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OrganizationServiceServer).DeleteOrganization(ctx, req.(*DeleteOrganizationRequest))
+		return srv.(OrganizationServiceServer).DeleteOrganization(ctx, req.(*OrganizationCrudRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -794,33 +482,27 @@ var _OrganizationService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "organization.proto",
 }
 
-func init() { proto.RegisterFile("organization.proto", fileDescriptor_organization_ab0b4e5ae001623e) }
+func init() { proto.RegisterFile("organization.proto", fileDescriptor_organization_b4ac988073079e62) }
 
-var fileDescriptor_organization_ab0b4e5ae001623e = []byte{
-	// 388 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x95, 0x51, 0x4b, 0x2a, 0x41,
-	0x14, 0xc7, 0x5d, 0xaf, 0x08, 0xf7, 0x5c, 0xb9, 0xf7, 0x72, 0x22, 0xd3, 0x29, 0x43, 0x07, 0x12,
-	0x9f, 0x0c, 0xac, 0x0f, 0x50, 0x28, 0x45, 0x11, 0x48, 0x53, 0xfb, 0xd2, 0x83, 0xb0, 0xea, 0x21,
-	0x84, 0x76, 0x67, 0x9b, 0x5d, 0x7d, 0xe8, 0x8b, 0xf5, 0xf5, 0x62, 0xdd, 0x5a, 0x56, 0x77, 0x46,
-	0xa5, 0xa5, 0x37, 0xf5, 0x9c, 0xf3, 0x9b, 0xdf, 0x0c, 0xe7, 0x8f, 0x80, 0x52, 0x3d, 0x3b, 0xde,
-	0xec, 0xcd, 0x09, 0x67, 0xd2, 0xeb, 0xfa, 0x4a, 0x86, 0x12, 0x8b, 0xfe, 0x98, 0xdf, 0x42, 0x65,
-	0x98, 0xaa, 0x60, 0x1b, 0xfe, 0xa6, 0x3b, 0x6f, 0x06, 0x35, 0xab, 0x69, 0x75, 0x7e, 0x89, 0xb5,
-	0x5f, 0x11, 0xa1, 0xe4, 0x39, 0x2e, 0xd5, 0x8a, 0x4d, 0xab, 0xf3, 0x5b, 0x2c, 0x3f, 0xf3, 0x53,
-	0xa8, 0xf7, 0x15, 0x39, 0x21, 0xa5, 0x89, 0x82, 0x5e, 0xe7, 0x14, 0x84, 0xc9, 0x80, 0x95, 0x1a,
-	0x10, 0xc0, 0x74, 0x03, 0x81, 0x2f, 0xbd, 0x80, 0xf0, 0x1c, 0x2a, 0xe9, 0x43, 0x97, 0x93, 0x7f,
-	0x7a, 0xff, 0xbb, 0xfe, 0xb8, 0xbb, 0xd2, 0xbf, 0xd2, 0xc5, 0x2f, 0xa0, 0x7a, 0x4d, 0xa1, 0xce,
-	0x60, 0xc7, 0xab, 0xf1, 0x21, 0x1c, 0x64, 0x08, 0xb9, 0x94, 0xee, 0xa1, 0x6e, 0xfb, 0x53, 0xc3,
-	0xbb, 0x7c, 0x0f, 0x29, 0x80, 0xe9, 0x90, 0xb9, 0x34, 0xfb, 0x50, 0x1f, 0xd0, 0x0b, 0xe9, 0x35,
-	0x77, 0x7d, 0x3c, 0x01, 0x4c, 0x07, 0xc9, 0x25, 0x36, 0x82, 0xa3, 0xcb, 0xe9, 0xd4, 0x0e, 0x48,
-	0x3d, 0x4a, 0x9d, 0x5b, 0x15, 0xca, 0xf3, 0x80, 0x54, 0xe2, 0xf4, 0xf9, 0x4d, 0xe3, 0x5c, 0xd4,
-	0x3a, 0xdb, 0xd0, 0x30, 0xf0, 0x73, 0x69, 0x4f, 0xa0, 0x25, 0xc8, 0x95, 0x0b, 0x8a, 0xc8, 0x57,
-	0x4a, 0xba, 0x3f, 0xe1, 0xfe, 0x04, 0x7c, 0xd3, 0x21, 0x79, 0x2e, 0xd0, 0x7b, 0x2f, 0xc1, 0x5e,
-	0xba, 0xfc, 0x40, 0x6a, 0x31, 0x9b, 0x10, 0xda, 0x80, 0xd9, 0xd8, 0x62, 0x23, 0xa2, 0x19, 0xf3,
-	0xcf, 0x8e, 0x4d, 0xe5, 0x58, 0x91, 0x17, 0xf0, 0x0e, 0xfe, 0xad, 0xe5, 0x0e, 0x59, 0x34, 0xa4,
-	0x8f, 0x33, 0x3b, 0xd4, 0xd6, 0x12, 0x9a, 0x0d, 0x98, 0x4d, 0x48, 0x2c, 0x69, 0x0c, 0x63, 0x2c,
-	0x69, 0x0e, 0x56, 0x8c, 0xcd, 0xee, 0x77, 0x8c, 0x35, 0x86, 0x27, 0xc6, 0x9a, 0x63, 0xc1, 0x0b,
-	0x38, 0x82, 0x7d, 0xed, 0x0a, 0x62, 0x33, 0x1a, 0xdd, 0xb4, 0xfd, 0xac, 0xb5, 0xa1, 0x23, 0xe1,
-	0xbb, 0xc0, 0xcc, 0x6b, 0x82, 0x27, 0x11, 0x62, 0xeb, 0xae, 0xb2, 0xf6, 0xb6, 0xb6, 0xaf, 0xe3,
-	0xc6, 0xe5, 0xe5, 0x1f, 0xcc, 0xd9, 0x47, 0x00, 0x00, 0x00, 0xff, 0xff, 0xa0, 0x5d, 0xf7, 0xf8,
-	0x76, 0x06, 0x00, 0x00,
+var fileDescriptor_organization_b4ac988073079e62 = []byte{
+	// 304 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x93, 0xcd, 0x4e, 0xbb, 0x40,
+	0x14, 0xc5, 0xff, 0xd0, 0xa6, 0xc9, 0xff, 0xda, 0x54, 0x73, 0xfd, 0x22, 0xd5, 0x05, 0x92, 0x68,
+	0xba, 0x62, 0x81, 0xbe, 0x80, 0x29, 0xd1, 0xd4, 0x48, 0x9a, 0x8c, 0xb2, 0xd5, 0x40, 0xe7, 0xc6,
+	0x90, 0x08, 0x83, 0xc3, 0xd0, 0x85, 0x0f, 0xe0, 0x73, 0x1b, 0x90, 0xc5, 0x50, 0x15, 0x13, 0x83,
+	0x3b, 0x60, 0x38, 0xbf, 0x73, 0x3f, 0xce, 0x00, 0x0a, 0xf9, 0x14, 0x65, 0xc9, 0x6b, 0xa4, 0x12,
+	0x91, 0xb9, 0xb9, 0x14, 0x4a, 0xa0, 0x99, 0xc7, 0x8e, 0x07, 0xe3, 0xa5, 0x76, 0x82, 0x13, 0x30,
+	0x13, 0x6e, 0x19, 0xb6, 0x31, 0x1b, 0x30, 0x33, 0xe1, 0x88, 0x30, 0xcc, 0xa2, 0x94, 0x2c, 0xd3,
+	0x36, 0x66, 0xff, 0x59, 0xfd, 0xec, 0x2c, 0xe1, 0x50, 0xd7, 0xcc, 0x65, 0xc9, 0x19, 0xbd, 0x94,
+	0x54, 0x28, 0xbc, 0x80, 0xb1, 0x6e, 0x54, 0x83, 0xb6, 0xbc, 0x1d, 0x37, 0x8f, 0x5d, 0x5d, 0xc2,
+	0x5a, 0x7f, 0x39, 0xb7, 0xb0, 0xd7, 0x3a, 0xa5, 0x22, 0x17, 0x59, 0x41, 0xbf, 0xa4, 0x3d, 0xc0,
+	0xf1, 0x25, 0xe7, 0x61, 0x41, 0xf2, 0x5e, 0xb4, 0xb1, 0x1f, 0x35, 0x1e, 0xc0, 0xa8, 0x2c, 0x48,
+	0x2e, 0xfc, 0xa6, 0xcd, 0xe6, 0x0d, 0xcf, 0x60, 0xa2, 0x73, 0x16, 0x7e, 0xdd, 0xf4, 0x80, 0x6d,
+	0x7c, 0x75, 0x56, 0x70, 0xc2, 0x28, 0x15, 0x6b, 0xaa, 0x2c, 0xae, 0xa4, 0x48, 0xff, 0xc0, 0xc4,
+	0x7b, 0x1b, 0xc2, 0xae, 0xce, 0xbd, 0x23, 0xb9, 0x4e, 0x56, 0x84, 0x01, 0xe0, 0x5c, 0x52, 0xa4,
+	0xa8, 0xb5, 0xb5, 0xa3, 0xcd, 0x91, 0x68, 0x3b, 0x99, 0x5a, 0x9f, 0xe6, 0xd5, 0xcc, 0xd7, 0xf9,
+	0x87, 0x37, 0xb0, 0x7d, 0x4d, 0xaa, 0x1f, 0x56, 0x00, 0x18, 0xe6, 0xbc, 0xb7, 0xd2, 0x02, 0x40,
+	0x9f, 0x9e, 0xa9, 0x2f, 0x5c, 0x08, 0xfb, 0x5f, 0xa6, 0x02, 0xed, 0x4a, 0xd4, 0x15, 0x98, 0x4e,
+	0xec, 0x23, 0x4c, 0xbf, 0x0f, 0x03, 0x9e, 0x56, 0xca, 0x1f, 0xc3, 0xd2, 0x65, 0x10, 0x8f, 0xea,
+	0xbb, 0x7a, 0xfe, 0x1e, 0x00, 0x00, 0xff, 0xff, 0x22, 0x8a, 0x71, 0xb9, 0xc1, 0x03, 0x00, 0x00,
 }

--- a/src/pb/organization.proto
+++ b/src/pb/organization.proto
@@ -11,14 +11,6 @@ message OrganizationCrudRequest {
     Organization organization = 1;
 }
 
-message CreateOrgRequest {
-    Organization organization = 1;
-}
-
-message CreateOrgResponse {
-    Organization organization = 1;
-}
-
 message OrganizationResponse {
     Organization organization = 1;
 }
@@ -34,7 +26,7 @@ message RemoveUserFromOrganizationRequest {
 }
 
 service OrganizationService {
-    rpc CreateOrganization (CreateOrgRequest) returns (CreateOrgResponse) {}
+    rpc CreateOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
     rpc GetOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
     rpc UpdateOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
     rpc DeleteOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}

--- a/src/pb/organization.proto
+++ b/src/pb/organization.proto
@@ -11,6 +11,14 @@ message OrganizationCrudRequest {
     Organization organization = 1;
 }
 
+message CreateOrgRequest {
+    Organization organization = 1;
+}
+
+message CreateOrgResponse {
+    Organization organization = 1;
+}
+
 message OrganizationResponse {
     Organization organization = 1;
 }
@@ -26,7 +34,7 @@ message RemoveUserFromOrganizationRequest {
 }
 
 service OrganizationService {
-    rpc CreateOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
+    rpc CreateOrganization (CreateOrgRequest) returns (CreateOrgResponse) {}
     rpc GetOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
     rpc UpdateOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
     rpc DeleteOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}

--- a/src/pb/organization.proto
+++ b/src/pb/organization.proto
@@ -3,39 +3,15 @@ syntax = "proto3";
 package pb;
 
 message Organization {
-    int64 organizationID = 1;
+    int64 id = 1;
     string name = 2;
 }
 
-message CreateOrganizationRequest {
-    string name = 1;
-}
-
-message CreateOrganizationResponse {
+message OrganizationCrudRequest {
     Organization organization = 1;
 }
 
-message GetOrganizationRequest {
-    int64 organizationID = 1;
-}
-
-message GetOrganizationResponse {
-    Organization organization = 1;
-}
-
-message UpdateOrganizationRequest {
-    Organization organization = 1;
-}
-
-message UpdateOrganizationResponse {
-    Organization organization = 1;
-}
-
-message DeleteOrganizationRequest {
-    int64 organizationID = 1;
-}
-
-message DeleteOrganizationResponse {
+message OrganizationResponse {
     Organization organization = 1;
 }
 
@@ -44,24 +20,16 @@ message AddUserToOrganizationRequest {
     int64 organizationID = 2;
 }
 
-message AddUserToOrganizationResponse {
-    Organization organization = 1;
-}
-
 message RemoveUserFromOrganizationRequest {
     int64 userID = 1;
     int64 organizationID = 2;
 }
 
-message RemoveUserFromOrganizationResponse {
-    Organization organization = 1;
-}
-
 service OrganizationService {
-    rpc CreateOrganization (CreateOrganizationRequest) returns (CreateOrganizationResponse) {}
-    rpc GetOrganization (GetOrganizationRequest) returns (GetOrganizationResponse) {}
-    rpc UpdateOrganization (UpdateOrganizationRequest) returns (UpdateOrganizationResponse) {}
-    rpc DeleteOrganization (DeleteOrganizationRequest) returns (DeleteOrganizationResponse) {}
-    rpc AddUserToOrganization (AddUserToOrganizationRequest) returns (AddUserToOrganizationResponse) {}
-    rpc RemoveUserFromOrganization (RemoveUserFromOrganizationRequest) returns (RemoveUserFromOrganizationResponse) {}
+    rpc CreateOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
+    rpc GetOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
+    rpc UpdateOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
+    rpc DeleteOrganization (OrganizationCrudRequest) returns (OrganizationResponse) {}
+    rpc AddUserToOrganization (AddUserToOrganizationRequest) returns (OrganizationResponse) {}
+    rpc RemoveUserFromOrganization (RemoveUserFromOrganizationRequest) returns (OrganizationResponse) {}
 }

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -50,6 +50,24 @@ func NewError(httpCode int, errorMessage string, err error) *Error {
 	}
 }
 
+func NotFound(msg string) *Error {
+	return &Error{
+		HttpCode:     http.StatusNotFound,
+		GrpcCode:     codes.NotFound,
+		ErrorMessage: msg,
+		Error:        nil,
+	}
+}
+
+func AlreadyExists(msg string) *Error {
+	return &Error{
+		HttpCode:     http.StatusBadRequest,
+		GrpcCode:     codes.AlreadyExists,
+		ErrorMessage: msg,
+		Error:        nil,
+	}
+}
+
 func Internal(err error) *Error {
 	return &Error{
 		HttpCode:     http.StatusInternalServerError,

--- a/src/user/neo/neo.go
+++ b/src/user/neo/neo.go
@@ -31,7 +31,7 @@ func (s *Service) CreateUser(resource user.User) (*user.User, *service.Error) {
 		return nil, service.Internal(err)
 	}
 	if exists {
-		return nil, service.NewError(http.StatusBadRequest, "User already exists with that email", nil)
+		return nil, service.AlreadyExists("User already exists with that email")
 	}
 
 	err = createUser(session, resource)

--- a/src/user/neo/neo.go
+++ b/src/user/neo/neo.go
@@ -1,8 +1,6 @@
 package neo
 
 import (
-	"net/http"
-
 	"github.com/kevinmichaelchen/neo4j-go-file-system/service"
 
 	"github.com/kevinmichaelchen/neo4j-go-file-system/neo"


### PR DESCRIPTION
Here's the call I'm making
```bash
grpcurl -v -plaintext -d '{"organization": {"id": 2, "name": "My Custom Org"}}' localhost:50051 pb.OrganizationService/CreateOrganization
```

I can see that the org is getting created, but the gRPC response never comes back because we get a panic when creating the response.
```
panic: runtime error: invalid memory address or nil pointer dereference
```